### PR TITLE
Improve how Notes are added and improve how bullets are interpreted

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 - Uses the latest Harvest API (v2)
 
 ## Installation & setup
-Install the latest version which you can find under [Releases](https://github.com/ajilderda/alfred-harvest-v2/releases).
+
+Install the latest version which you can find under [Releases](https://github.com/andrejilderda/alfred-harvest-v2/releases).
+
 1. Make sure you have [node.js](https://nodejs.org/en/) installed. To check run `node -v` from your terminal.
 2. Go to https://id.getharvest.com/developers › 'Create New Personal Access Token' and give it a name, i.e. 'Alfred workflow'.
 3. Copy the access token and remember your Account ID.
@@ -16,12 +18,14 @@ Install the latest version which you can find under [Releases](https://github.co
 6. Type your 6-digit Account ID and press <kbd>enter</kbd>,
 7. Type `hvn` and start your first timer!
 
-*The first time you run the workflow you may be prompted to grant access to the API token (which is stored in your Keychain).
+\*The first time you run the workflow you may be prompted to grant access to the API token (which is stored in your Keychain).
 
 _Note: In order to install workflows you need the [Alfred Powerpack](https://www.alfredapp.com/powerpack/)._
 
 ## How to use
+
 ### Start a new timer
+
 ![Start a new timer](https://user-images.githubusercontent.com/487182/68616415-48858600-04c5-11ea-921c-38d3b8d0217b.gif)
 
 - Type <kbd>hvn</kbd> to list the available projects,
@@ -29,6 +33,7 @@ _Note: In order to install workflows you need the [Alfred Powerpack](https://www
 - Select the task and press <kbd>enter</kbd>
 
 ### Toggle timer
+
 ![Toggle timer](https://user-images.githubusercontent.com/487182/68616434-4f13fd80-04c5-11ea-8379-77b7ba7919e0.gif)
 
 - Type `hvt` to list today's timers.
@@ -37,6 +42,7 @@ _Note: In order to install workflows you need the [Alfred Powerpack](https://www
 **Tip:** Hold <kbd>alt</kbd> to delete the selected task.
 
 ### Adjust timer
+
 ![Adjust timer](https://user-images.githubusercontent.com/487182/68617779-3bb66180-04c8-11ea-8ea8-2b35ebe934ad.gif)
 
 - Type `hva` to list today's timers,
@@ -46,6 +52,7 @@ _Note: In order to install workflows you need the [Alfred Powerpack](https://www
 **Tip:** Add a `+`/`-` in front of your timer to add or subtract time, i.e. `-30m` will subtract 30 minutes from your timer.
 
 ### Add notes
+
 ![Add note](https://user-images.githubusercontent.com/487182/68617778-3bb66180-04c8-11ea-9951-ee7d23e10fdc.gif)
 
 - Type `hvnt` to list today's timers,
@@ -54,6 +61,7 @@ _Note: In order to install workflows you need the [Alfred Powerpack](https://www
 **Tip:** Your newly typed note will be appended by default. If you want to overwrite the note, hold down the <kbd>alt</kbd>-key when selecting a task from the list.
 
 ## Credits & thank you’s
+
 This workflow was inspired by Neil Renicker’s [Harvest workflow](https://github.com/tinystride/alfred-harvest) which I've used for years (but stopped working for me).
 
 All icons (except the Harvest logo) are from Daniel Bruce’s [Entypo](http://www.entypo.com/)-pack, and are distributed under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)-license.

--- a/info.plist
+++ b/info.plist
@@ -979,8 +979,8 @@
 				<integer>0</integer>
 				<key>script</key>
 				<string># THESE VARIABLES MUST BE SET. SEE THE ONEUPDATER README FOR AN EXPLANATION OF EACH.
-readonly remote_info_plist='https://raw.githubusercontent.com/ajilderda/alfred-harvest-v2/master/info.plist'
-readonly workflow_url='ajilderda/alfred-harvest-v2'
+readonly remote_info_plist='https://raw.githubusercontent.com/andrejilderda/alfred-harvest-v2/master/info.plist'
+readonly workflow_url='andrejilderda/alfred-harvest-v2'
 readonly download_type='github_release'
 readonly frequency_check='4'
 
@@ -1223,7 +1223,7 @@ fi</string>
 				<key>spaces</key>
 				<string></string>
 				<key>url</key>
-				<string>https://github.com/ajilderda/alfred-harvest-v2#installation--setup</string>
+				<string>https://github.com/andrejilderda/alfred-harvest-v2#installation--setup</string>
 				<key>utf8</key>
 				<true/>
 			</dict>
@@ -1300,7 +1300,7 @@ fi</string>
 	</array>
 	<key>readme</key>
 	<string>For more information head over to:
-https://github.com/ajilderda/alfred-harvest-v2</string>
+https://github.com/andrejilderda/alfred-harvest-v2</string>
 	<key>uidata</key>
 	<dict>
 		<key>0113364C-D18F-4B1C-B082-9579BE03D03C</key>
@@ -1558,8 +1558,8 @@ https://github.com/ajilderda/alfred-harvest-v2</string>
 	<key>variablesdontexport</key>
 	<array/>
 	<key>version</key>
-	<string>1.1.4</string>
+	<string>1.1.5</string>
 	<key>webaddress</key>
-	<string>https://github.com/ajilderda/alfred-harvest-v2</string>
+	<string>https://github.com/andrejilderda/alfred-harvest-v2</string>
 </dict>
 </plist>

--- a/src/update-task.js
+++ b/src/update-task.js
@@ -1,75 +1,69 @@
-import { apiCall } from './utils/helpers';
-import { notify } from './utils/notifications';
+import { apiCall } from "./utils/helpers";
+import { notify } from "./utils/notifications";
 
 const vars = process.env;
 const { action, goTo, taskId, taskNotes, requestMethod, taskHours } = vars;
-const stopRestart = vars.stopRestart || '';
+const stopRestart = vars.stopRestart || "";
 
 let url = `https://api.harvestapp.com/v2/time_entries/${taskId}/${stopRestart}`;
 
-if (action === 'note') {
-    const prevNote = taskNotes || '';
+if (action === "note") {
+  const prevNote = taskNotes || "";
+  const newNote = process.argv[2];
+  const bulletRegex = /^(\*|•|-|–)\s?/g;
+  const match = newNote.match(bulletRegex);
 
-    // Convert any bullets.
-    const newNote = process.argv[2].replace(/^(\-|\*|\–)\s?/g, (0 === prevNote.length) ? '\u2022 ' : '\u2022 ');
+  // Convert any bullets (dash and en-dashes to '– ' and asterisks and bullets to '• ')
+  const bulletChar = !match
+    ? ""
+    : match[0].trim() === "*" || match[0].trim() === "•"
+    ? "• "
+    : "– ";
 
-    // Format previous notes from new notes.
-    const newFormattedNote = (0 === prevNote.length)
-        ? newNote // Just use the new note without any concern for the previous (because there is none).
+  const newNoteFormatted = process.argv[2].replace(bulletRegex, bulletChar);
 
-        // Separate notes/bullets from previous.
-        : (-1 !== newNote.indexOf('\u2022'))
-            ? `${prevNote}\n${newNote}` // Bullets get a single line separator \n from the previous note (bullet or otherwise).
-            : `${prevNote}\n\n${newNote}`; // While all other notes get two separators \n\n from the previous.
+  // Format previous notes from new notes.
+  const noteFormatted = !prevNote.length
+    ? newNoteFormatted // Just use the new note without any concern for the previous (because there is none).
+    : bulletChar // Check if a bullet character was used
+    ? `${prevNote}\n${newNoteFormatted}` // Bullets get a single line separator \n from the previous note (bullet or otherwise).
+    : `${prevNote}\n\n${newNoteFormatted}`; // While all other notes get two separators \n\n from the previous.
 
-    const note = encodeURIComponent(newFormattedNote.trim());
+  const note = encodeURIComponent(noteFormatted.trim());
 
-    url = `https://api.harvestapp.com/v2/time_entries/${taskId}?notes=${note}`;
+  url = `https://api.harvestapp.com/v2/time_entries/${taskId}?notes=${note}`;
 }
 
-if (action === 'adjust-timer') {
-    url = `https://api.harvestapp.com/v2/time_entries/${taskId}?hours=${taskHours}`;
+if (action === "adjust-timer") {
+  url = `https://api.harvestapp.com/v2/time_entries/${taskId}?hours=${taskHours}`;
 }
 
 // bail when user is 'redirected' to other command
 if (!goTo) {
-
-    await apiCall(url, requestMethod)
-        .then(response => {
-            if (action === 'note') {
-                notify(
-                    'Harvest note updated!',
-                    response.notes
-                );
-            }
-            else if (action === 'adjust-timer') {
-                notify(
-                    'Harvest timer adjusted!',
-                    `Hours: ${response.hours}`
-                );
-            }
-            else if (stopRestart === 'stop') {
-                notify(
-                    'Harvest timer stopped!',
-                    `${response.project.name}, ${response.task.name}`
-                );
-            }
-            else if (stopRestart === 'restart') {
-                notify(
-                    'Harvest timer started!',
-                    `${response.project.name}, ${response.task.name}`
-                );
-            }
-            else {
-                notify(
-                    'Harvest timer updated!'
-                );
-            }
-        })
-        .catch(error => {
-            notify(
-                'Failed to update task.',
-                'Check your network connection and try again.'
-            );
-        });
+  await apiCall(url, requestMethod)
+    .then((response) => {
+      if (action === "note") {
+        notify("Harvest note updated!", response.notes);
+      } else if (action === "adjust-timer") {
+        notify("Harvest timer adjusted!", `Hours: ${response.hours}`);
+      } else if (stopRestart === "stop") {
+        notify(
+          "Harvest timer stopped!",
+          `${response.project.name}, ${response.task.name}`
+        );
+      } else if (stopRestart === "restart") {
+        notify(
+          "Harvest timer started!",
+          `${response.project.name}, ${response.task.name}`
+        );
+      } else {
+        notify("Harvest timer updated!");
+      }
+    })
+    .catch((error) => {
+      notify(
+        "Failed to update task.",
+        "Check your network connection and try again."
+      );
+    });
 }

--- a/src/update-task.js
+++ b/src/update-task.js
@@ -19,8 +19,8 @@ if (action === 'note') {
 
         // Separate notes/bullets from previous.
         : (-1 !== newNote.indexOf('\u2022'))
-            ? `${prevNote}\n${newNote}` // Bullets get a single line separator from the previous note (bullet or otherwise).
-            : `${prevNote}\n\n${newNote}`; // While all other notes get two separators from the previous note.;
+            ? `${prevNote}\n${newNote}` // Bullets get a single line separator \n from the previous note (bullet or otherwise).
+            : `${prevNote}\n\n${newNote}`; // While all other notes get two separators \n\n from the previous.
 
     const note = encodeURIComponent(newFormattedNote.trim());
 

--- a/src/update-task.js
+++ b/src/update-task.js
@@ -17,7 +17,7 @@ if (action === 'note') {
     const newFormattedNote = (0 === prevNote.length)
         ? newNote // Just use the new note without any concern for the previous (because there is none).
 
-        // Separate bullets and non-bullets from the previous.
+        // Separate notes/bullets from previous.
         : (-1 !== newNote.indexOf('\u2022'))
             ? `${prevNote}\n${newNote}` // Bullets get a single line separator from the previous note (bullet or otherwise).
             : `${prevNote}\n\n${newNote}`; // While all other notes get two separators from the previous note.;

--- a/src/update-task.js
+++ b/src/update-task.js
@@ -9,7 +9,7 @@ let url = `https://api.harvestapp.com/v2/time_entries/${taskId}/${stopRestart}`;
 
 if (action === 'note') {
     const prevNote = taskNotes || '';
-    const newNote = process.argv[2].replace(/^\-\s/g, (0 === prevNotelength) ? '-' : '\n- ');
+    const newNote = process.argv[2].replace(/^(\-|\*|\–)\s?/g, (0 === prevNote.length) ? '\u2022\ ' : '\n\u2022\ ');
     const note = encodeURIComponent(`${prevNote}${newNote}`);
     url = `https://api.harvestapp.com/v2/time_entries/${taskId}?notes=${note}`;
 }

--- a/src/update-task.js
+++ b/src/update-task.js
@@ -9,8 +9,8 @@ let url = `https://api.harvestapp.com/v2/time_entries/${taskId}/${stopRestart}`;
 
 if (action === 'note') {
     const prevNote = taskNotes || '';
-    const newNote = process.argv[2].replace(/^(\-|\*|\–)\s?/g, (0 === prevNote.length) ? '\u2022\ ' : '\n\u2022\ ');
-    const note = encodeURIComponent(0 === prevNote.length ? newNote : `${prevNote}${newNote}`);
+    const newNote = process.argv[2].replace(/^(\-|\*|\–)\s?/g, (0 === prevNote.length) ? '\u2022 ' : '\u2022 ');
+    const note = encodeURIComponent(0 === prevNote.length ? newNote : `${prevNote}\n\n${newNote}`);
     url = `https://api.harvestapp.com/v2/time_entries/${taskId}?notes=${note}`;
 }
 

--- a/src/update-task.js
+++ b/src/update-task.js
@@ -9,8 +9,21 @@ let url = `https://api.harvestapp.com/v2/time_entries/${taskId}/${stopRestart}`;
 
 if (action === 'note') {
     const prevNote = taskNotes || '';
+
+    // Convert any bullets.
     const newNote = process.argv[2].replace(/^(\-|\*|\–)\s?/g, (0 === prevNote.length) ? '\u2022 ' : '\u2022 ');
-    const note = encodeURIComponent(0 === prevNote.length ? newNote : `${prevNote}\n\n${newNote}`);
+
+    // Format previous notes from new notes.
+    const newFormattedNote = (0 === prevNote.length)
+        ? newNote // Just use the new note without any concern for the previous (because there is none).
+
+        // Separate bullets and non-bullets from the previous.
+        : (-1 !== newNote.indexOf('\u2022'))
+            ? `${prevNote}\n${newNote}` // Bullets get a single line separator from the previous note (bullet or otherwise).
+            : `${prevNote}\n\n${newNote}`; // While all other notes get two separators from the previous note.;
+
+    const note = encodeURIComponent(newFormattedNote.trim());
+
     url = `https://api.harvestapp.com/v2/time_entries/${taskId}?notes=${note}`;
 }
 

--- a/src/update-task.js
+++ b/src/update-task.js
@@ -9,7 +9,7 @@ let url = `https://api.harvestapp.com/v2/time_entries/${taskId}/${stopRestart}`;
 
 if (action === 'note') {
     const prevNote = taskNotes || '';
-    const newNote = process.argv[2].replace(/– /g, '\n– ')
+    const newNote = process.argv[2].replace(/^\-\s/g, (0 === prevNotelength) ? '-' : '\n- ');
     const note = encodeURIComponent(`${prevNote}${newNote}`);
     url = `https://api.harvestapp.com/v2/time_entries/${taskId}?notes=${note}`;
 }

--- a/src/update-task.js
+++ b/src/update-task.js
@@ -10,7 +10,7 @@ let url = `https://api.harvestapp.com/v2/time_entries/${taskId}/${stopRestart}`;
 if (action === 'note') {
     const prevNote = taskNotes || '';
     const newNote = process.argv[2].replace(/^(\-|\*|\–)\s?/g, (0 === prevNote.length) ? '\u2022\ ' : '\n\u2022\ ');
-    const note = encodeURIComponent(`${prevNote}${newNote}`);
+    const note = encodeURIComponent(0 === prevNote.length ? newNote : `${prevNote}${newNote}`);
     url = `https://api.harvestapp.com/v2/time_entries/${taskId}?notes=${note}`;
 }
 


### PR DESCRIPTION
See [this video](https://youtu.be/ToEVgEHXDns) for a demo.

- Notes now act like paragraphs and each note is separated out now
- Bullets act as sub-text (_see demo_)
- You can use `-`, `*`, or `–` to trigger a bullet w/out worry of hurting other char's in the text
	- Bullets (no matter what char you perfer) present as a `\u2022` or `•` in Harvest

Resolves #16